### PR TITLE
Fix Issue #10236: Make type hints for endpoint parameter consistent in add_api_route methods

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1056,7 +1056,7 @@ class FastAPI(Starlette):
     def add_api_route(
         self,
         path: str,
-        endpoint: Callable[..., Coroutine[Any, Any, Response]],
+        endpoint: Callable[..., Any],
         *,
         response_model: Any = Default(None),
         status_code: Optional[int] = None,


### PR DESCRIPTION
This pull request addresses issue #10236 by ensuring that the type hint for the `endpoint` parameter in the `add_api_route` method of the `FastAPI` class is consistent with `APIRouter.add_api_route`. The type hint has been changed to `Callable[..., Any]`.