### PR TITLE
Fix type hint inconsistency in add_api_route method

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1056,7 +1056,7 @@ class FastAPI(Starlette):
     def add_api_route(
         self,
         path: str,
-        endpoint: Callable[..., Coroutine[Any, Any, Response]],
+        endpoint: Callable[..., Any],
         *,
         response_model: Any = Default(None),
         status_code: Optional[int] = None,


### PR DESCRIPTION
This pull request addresses the type hint inconsistency in the `add_api_route` method of the `applications.py` file, ensuring consistency with the `APIRouter.add_api_route` method.